### PR TITLE
Remove unnecessary calls for time.Now()

### DIFF
--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -123,7 +123,6 @@ func (q *Collector) execute() {
 	columnNames, err := rows.Columns()
 	if err != nil {
 		q.err = fmt.Errorf("query [%s] fail retriving rows meta: %w", q.Name, err)
-		q.scrapeDone = time.Now()
 		return
 	}
 	columnIndexes := make(map[string]int, len(columnNames)) // column name to index
@@ -145,7 +144,6 @@ func (q *Collector) execute() {
 		err = rows.Scan(colArgs...)
 		if err != nil {
 			q.err = fmt.Errorf("fail scanning rows: %w", err)
-			q.scrapeDone = time.Now()
 			return
 		}
 


### PR DESCRIPTION
In execute() function, it calls time.Now() to set scrapeDone when there
is an error.  However, it also set the scrapeDone in Collect(), so it's
redundant to set scrapeDone in execute().