### PR TITLE
Support PostgreSQL 15 and higher

### DIFF
--- a/config/collector/110-pg.yml
+++ b/config/collector/110-pg.yml
@@ -11,7 +11,7 @@
 #       Priority   0
 #       Timeout    100ms
 #       Fatal      true
-#       Version    100000 ~ higher
+#       Version    100000 ~ 150000
 #       Source     110-pg.yml
 #
 # METRICS
@@ -74,7 +74,7 @@ pg_primary_only:
     ttl: 1
     timeout: 0.1
     min_version: 100000
-    max_version: 0
+    max_version: 150000
     fatal: true
     skip: false
     metrics:
@@ -145,6 +145,137 @@ pg_primary_only:
 
 ##
 # SYNNOPSIS
+#       pg.pg_primary_only_15_*
+#
+# DESCRIPTION
+#       PostgreSQL basic information (on primary)
+#
+# OPTIONS
+#       Tags       [cluster, primary]
+#       TTL        1
+#       Priority   0
+#       Timeout    100ms
+#       Fatal      true
+#       Version    150000 ~ higher
+#       Source     110-pg.yml
+#
+# METRICS
+#       timestamp (GAUGE)
+#           current database timestamp in unix epoch
+#       uptime (GAUGE)
+#           seconds since postmaster start
+#       boot_time (GAUGE)
+#           postmaster boot timestamp in unix epoch
+#       lsn (COUNTER)
+#           log sequence number, current write location
+#       insert_lsn (COUNTER)
+#           primary only, location of current wal inserting
+#       write_lsn (COUNTER)
+#           primary only, location of current wal writing
+#       flush_lsn (COUNTER)
+#           primary only, location of current wal syncing
+#       receive_lsn (COUNTER)
+#           replica only, location of wal synced to disk
+#       replay_lsn (COUNTER)
+#           replica only, location of wal applied
+#       conf_reload_time (GAUGE)
+#           seconds since last configuration reload
+#       last_replay_time (GAUGE)
+#           time when last transaction been replayed
+#       lag (GAUGE)
+#           replica only, replication lag in seconds
+#       is_in_recovery (GAUGE)
+#           1 if in recovery mode
+#       is_wal_replay_paused (GAUGE)
+#           1 if wal play is paused
+#
+pg_primary_only_15:
+    name: pg
+    desc: PostgreSQL basic information (on primary)
+    query: |
+        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                  AS timestamp,
+               extract(EPOCH FROM now() - pg_postmaster_start_time()) AS uptime,
+               extract(EPOCH FROM pg_postmaster_start_time())         AS boot_time,
+               pg_current_wal_lsn() - '0/0'                           AS lsn,
+               pg_current_wal_insert_lsn() - '0/0'                    AS insert_lsn,
+               pg_current_wal_lsn() - '0/0'                           AS write_lsn,
+               pg_current_wal_flush_lsn() - '0/0'                     AS flush_lsn,
+               NULL::BIGINT                                           AS receive_lsn,
+               NULL::BIGINT                                           AS replay_lsn,
+               extract(EPOCH FROM now() - pg_conf_load_time())        AS conf_reload_time,
+               NULL::FLOAT                                            AS last_replay_time,
+               0::FLOAT                                               AS lag,
+               pg_is_in_recovery()                                    AS is_in_recovery,
+               FALSE                                                  AS is_wal_replay_paused;
+    tags:
+        - cluster
+        - primary
+    ttl: 1
+    timeout: 0.1
+    min_version: 150000
+    max_version: 0
+    fatal: true
+    skip: false
+    metrics:
+        - timestamp:
+            name: timestamp
+            usage: GAUGE
+            description: current database timestamp in unix epoch
+        - uptime:
+            name: uptime
+            usage: GAUGE
+            description: seconds since postmaster start
+        - boot_time:
+            name: boot_time
+            usage: GAUGE
+            description: postmaster boot timestamp in unix epoch
+        - lsn:
+            name: lsn
+            usage: COUNTER
+            description: log sequence number, current write location
+        - insert_lsn:
+            name: insert_lsn
+            usage: COUNTER
+            description: primary only, location of current wal inserting
+        - write_lsn:
+            name: write_lsn
+            usage: COUNTER
+            description: primary only, location of current wal writing
+        - flush_lsn:
+            name: flush_lsn
+            usage: COUNTER
+            description: primary only, location of current wal syncing
+        - receive_lsn:
+            name: receive_lsn
+            usage: COUNTER
+            description: replica only, location of wal synced to disk
+        - replay_lsn:
+            name: replay_lsn
+            usage: COUNTER
+            description: replica only, location of wal applied
+        - conf_reload_time:
+            name: conf_reload_time
+            usage: GAUGE
+            description: seconds since last configuration reload
+        - last_replay_time:
+            name: last_replay_time
+            usage: GAUGE
+            description: time when last transaction been replayed
+        - lag:
+            name: lag
+            usage: GAUGE
+            description: replica only, replication lag in seconds
+        - is_in_recovery:
+            name: is_in_recovery
+            usage: GAUGE
+            description: 1 if in recovery mode
+        - is_wal_replay_paused:
+            name: is_wal_replay_paused
+            usage: GAUGE
+            description: 1 if wal play is paused
+
+##
+# SYNNOPSIS
 #       pg.pg_replica_only_*
 #
 # DESCRIPTION
@@ -156,7 +287,7 @@ pg_primary_only:
 #       Priority   0
 #       Timeout    100ms
 #       Fatal      true
-#       Version    100000 ~ higher
+#       Version    100000 ~ 150000
 #       Source     110-pg.yml
 #
 # METRICS
@@ -221,7 +352,7 @@ pg_replica_only:
     ttl: 1
     timeout: 0.1
     min_version: 100000
-    max_version: 0
+    max_version: 150000
     fatal: true
     skip: false
     metrics:
@@ -290,4 +421,136 @@ pg_replica_only:
             usage: GAUGE
             description: seconds since current backup start
 
+##
+# SYNNOPSIS
+#       pg.pg_replica_only_15_*
+#
+# DESCRIPTION
+#       PostgreSQL basic information (on replica)
+#
+# OPTIONS
+#       Tags       [cluster, replica]
+#       TTL        1
+#       Priority   0
+#       Timeout    100ms
+#       Fatal      true
+#       Version    150000 ~ higher
+#       Source     110-pg.yml
+#
+# METRICS
+#       timestamp (GAUGE)
+#           database current timestamp
+#       uptime (GAUGE)
+#           seconds since postmaster start
+#       boot_time (GAUGE)
+#           unix timestamp when postmaster boot
+#       lsn (COUNTER)
+#           log sequence number, current write location
+#       insert_lsn (COUNTER)
+#           primary only, location of current wal inserting
+#       write_lsn (COUNTER)
+#           primary only, location of current wal writing
+#       flush_lsn (COUNTER)
+#           primary only, location of current wal syncing
+#       receive_lsn (COUNTER)
+#           replica only, location of wal synced to disk
+#       replay_lsn (COUNTER)
+#           replica only, location of wal applied
+#       conf_reload_time (GAUGE)
+#           seconds since last configuration reload
+#       last_replay_time (GAUGE)
+#           time when last transaction been replayed
+#       lag (GAUGE)
+#           replica only, replication lag in seconds
+#       is_in_recovery (GAUGE)
+#           1 if in recovery mode
+#       is_wal_replay_paused (GAUGE)
+#           1 if wal play paused
+#
+pg_replica_only_15:
+    name: pg
+    desc: PostgreSQL basic information (on replica)
+    query: |
+        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                                    AS timestamp,
+               extract(EPOCH FROM now() - pg_postmaster_start_time())                   AS uptime,
+               extract(EPOCH FROM pg_postmaster_start_time())                           AS boot_time,
+               pg_last_wal_replay_lsn() - '0/0'                                         AS lsn,
+               NULL::BIGINT                                                             AS insert_lsn,
+               NULL::BIGINT                                                             AS write_lsn,
+               NULL::BIGINT                                                             AS flush_lsn,
+               pg_last_wal_receive_lsn() - '0/0'                                        AS receive_lsn,
+               pg_last_wal_replay_lsn() - '0/0'                                         AS replay_lsn,
+               extract(EPOCH FROM now() - pg_conf_load_time())                          AS conf_reload_time,
+               extract(EPOCH FROM pg_last_xact_replay_timestamp())                      AS last_replay_time,
+               CASE
+                   WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
+                   ELSE EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()) END AS lag,
+               pg_is_in_recovery()                                                      AS is_in_recovery,
+               pg_is_wal_replay_paused()                                                AS is_wal_replay_paused;
+    tags:
+        - cluster
+        - replica
+    ttl: 1
+    timeout: 0.1
+    min_version: 150000
+    max_version: 0
+    fatal: true
+    skip: false
+    metrics:
+        - timestamp:
+            name: timestamp
+            usage: GAUGE
+            description: database current timestamp
+        - uptime:
+            name: uptime
+            usage: GAUGE
+            description: seconds since postmaster start
+        - boot_time:
+            name: boot_time
+            usage: GAUGE
+            description: unix timestamp when postmaster boot
+        - lsn:
+            name: lsn
+            usage: COUNTER
+            description: log sequence number, current write location
+        - insert_lsn:
+            name: insert_lsn
+            usage: COUNTER
+            description: primary only, location of current wal inserting
+        - write_lsn:
+            name: write_lsn
+            usage: COUNTER
+            description: primary only, location of current wal writing
+        - flush_lsn:
+            name: flush_lsn
+            usage: COUNTER
+            description: primary only, location of current wal syncing
+        - receive_lsn:
+            name: receive_lsn
+            usage: COUNTER
+            description: replica only, location of wal synced to disk
+        - replay_lsn:
+            name: replay_lsn
+            usage: COUNTER
+            description: replica only, location of wal applied
+        - conf_reload_time:
+            name: conf_reload_time
+            usage: GAUGE
+            description: seconds since last configuration reload
+        - last_replay_time:
+            name: last_replay_time
+            usage: GAUGE
+            description: time when last transaction been replayed
+        - lag:
+            name: lag
+            usage: GAUGE
+            description: replica only, replication lag in seconds
+        - is_in_recovery:
+            name: is_in_recovery
+            usage: GAUGE
+            description: 1 if in recovery mode
+        - is_wal_replay_paused:
+            name: is_wal_replay_paused
+            usage: GAUGE
+            description: 1 if wal play paused
 

--- a/pg_exporter.yml
+++ b/pg_exporter.yml
@@ -211,7 +211,7 @@
 #       Priority   0
 #       Timeout    100ms
 #       Fatal      true
-#       Version    100000 ~ higher
+#       Version    100000 ~ 150000
 #       Source     110-pg.yml
 #
 # METRICS
@@ -274,7 +274,7 @@ pg_primary_only:
     ttl: 1
     timeout: 0.1
     min_version: 100000
-    max_version: 0
+    max_version: 150000
     fatal: true
     skip: false
     metrics:
@@ -345,6 +345,137 @@ pg_primary_only:
 
 ##
 # SYNNOPSIS
+#       pg.pg_primary_only_15_*
+#
+# DESCRIPTION
+#       PostgreSQL basic information (on primary)
+#
+# OPTIONS
+#       Tags       [cluster, primary]
+#       TTL        1
+#       Priority   0
+#       Timeout    100ms
+#       Fatal      true
+#       Version    150000 ~ higher
+#       Source     110-pg.yml
+#
+# METRICS
+#       timestamp (GAUGE)
+#           current database timestamp in unix epoch
+#       uptime (GAUGE)
+#           seconds since postmaster start
+#       boot_time (GAUGE)
+#           postmaster boot timestamp in unix epoch
+#       lsn (COUNTER)
+#           log sequence number, current write location
+#       insert_lsn (COUNTER)
+#           primary only, location of current wal inserting
+#       write_lsn (COUNTER)
+#           primary only, location of current wal writing
+#       flush_lsn (COUNTER)
+#           primary only, location of current wal syncing
+#       receive_lsn (COUNTER)
+#           replica only, location of wal synced to disk
+#       replay_lsn (COUNTER)
+#           replica only, location of wal applied
+#       conf_reload_time (GAUGE)
+#           seconds since last configuration reload
+#       last_replay_time (GAUGE)
+#           time when last transaction been replayed
+#       lag (GAUGE)
+#           replica only, replication lag in seconds
+#       is_in_recovery (GAUGE)
+#           1 if in recovery mode
+#       is_wal_replay_paused (GAUGE)
+#           1 if wal play is paused
+#
+pg_primary_only_15:
+    name: pg
+    desc: PostgreSQL basic information (on primary)
+    query: |
+        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                  AS timestamp,
+               extract(EPOCH FROM now() - pg_postmaster_start_time()) AS uptime,
+               extract(EPOCH FROM pg_postmaster_start_time())         AS boot_time,
+               pg_current_wal_lsn() - '0/0'                           AS lsn,
+               pg_current_wal_insert_lsn() - '0/0'                    AS insert_lsn,
+               pg_current_wal_lsn() - '0/0'                           AS write_lsn,
+               pg_current_wal_flush_lsn() - '0/0'                     AS flush_lsn,
+               NULL::BIGINT                                           AS receive_lsn,
+               NULL::BIGINT                                           AS replay_lsn,
+               extract(EPOCH FROM now() - pg_conf_load_time())        AS conf_reload_time,
+               NULL::FLOAT                                            AS last_replay_time,
+               0::FLOAT                                               AS lag,
+               pg_is_in_recovery()                                    AS is_in_recovery,
+               FALSE                                                  AS is_wal_replay_paused;
+    tags:
+        - cluster
+        - primary
+    ttl: 1
+    timeout: 0.1
+    min_version: 150000
+    max_version: 0
+    fatal: true
+    skip: false
+    metrics:
+        - timestamp:
+            name: timestamp
+            usage: GAUGE
+            description: current database timestamp in unix epoch
+        - uptime:
+            name: uptime
+            usage: GAUGE
+            description: seconds since postmaster start
+        - boot_time:
+            name: boot_time
+            usage: GAUGE
+            description: postmaster boot timestamp in unix epoch
+        - lsn:
+            name: lsn
+            usage: COUNTER
+            description: log sequence number, current write location
+        - insert_lsn:
+            name: insert_lsn
+            usage: COUNTER
+            description: primary only, location of current wal inserting
+        - write_lsn:
+            name: write_lsn
+            usage: COUNTER
+            description: primary only, location of current wal writing
+        - flush_lsn:
+            name: flush_lsn
+            usage: COUNTER
+            description: primary only, location of current wal syncing
+        - receive_lsn:
+            name: receive_lsn
+            usage: COUNTER
+            description: replica only, location of wal synced to disk
+        - replay_lsn:
+            name: replay_lsn
+            usage: COUNTER
+            description: replica only, location of wal applied
+        - conf_reload_time:
+            name: conf_reload_time
+            usage: GAUGE
+            description: seconds since last configuration reload
+        - last_replay_time:
+            name: last_replay_time
+            usage: GAUGE
+            description: time when last transaction been replayed
+        - lag:
+            name: lag
+            usage: GAUGE
+            description: replica only, replication lag in seconds
+        - is_in_recovery:
+            name: is_in_recovery
+            usage: GAUGE
+            description: 1 if in recovery mode
+        - is_wal_replay_paused:
+            name: is_wal_replay_paused
+            usage: GAUGE
+            description: 1 if wal play is paused
+
+##
+# SYNNOPSIS
 #       pg.pg_replica_only_*
 #
 # DESCRIPTION
@@ -356,7 +487,7 @@ pg_primary_only:
 #       Priority   0
 #       Timeout    100ms
 #       Fatal      true
-#       Version    100000 ~ higher
+#       Version    100000 ~ 150000
 #       Source     110-pg.yml
 #
 # METRICS
@@ -421,7 +552,7 @@ pg_replica_only:
     ttl: 1
     timeout: 0.1
     min_version: 100000
-    max_version: 0
+    max_version: 150000
     fatal: true
     skip: false
     metrics:
@@ -490,6 +621,138 @@ pg_replica_only:
             usage: GAUGE
             description: seconds since current backup start
 
+##
+# SYNNOPSIS
+#       pg.pg_replica_only_15_*
+#
+# DESCRIPTION
+#       PostgreSQL basic information (on replica)
+#
+# OPTIONS
+#       Tags       [cluster, replica]
+#       TTL        1
+#       Priority   0
+#       Timeout    100ms
+#       Fatal      true
+#       Version    150000 ~ higher
+#       Source     110-pg.yml
+#
+# METRICS
+#       timestamp (GAUGE)
+#           database current timestamp
+#       uptime (GAUGE)
+#           seconds since postmaster start
+#       boot_time (GAUGE)
+#           unix timestamp when postmaster boot
+#       lsn (COUNTER)
+#           log sequence number, current write location
+#       insert_lsn (COUNTER)
+#           primary only, location of current wal inserting
+#       write_lsn (COUNTER)
+#           primary only, location of current wal writing
+#       flush_lsn (COUNTER)
+#           primary only, location of current wal syncing
+#       receive_lsn (COUNTER)
+#           replica only, location of wal synced to disk
+#       replay_lsn (COUNTER)
+#           replica only, location of wal applied
+#       conf_reload_time (GAUGE)
+#           seconds since last configuration reload
+#       last_replay_time (GAUGE)
+#           time when last transaction been replayed
+#       lag (GAUGE)
+#           replica only, replication lag in seconds
+#       is_in_recovery (GAUGE)
+#           1 if in recovery mode
+#       is_wal_replay_paused (GAUGE)
+#           1 if wal play paused
+#
+pg_replica_only_15:
+    name: pg
+    desc: PostgreSQL basic information (on replica)
+    query: |
+        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                                    AS timestamp,
+               extract(EPOCH FROM now() - pg_postmaster_start_time())                   AS uptime,
+               extract(EPOCH FROM pg_postmaster_start_time())                           AS boot_time,
+               pg_last_wal_replay_lsn() - '0/0'                                         AS lsn,
+               NULL::BIGINT                                                             AS insert_lsn,
+               NULL::BIGINT                                                             AS write_lsn,
+               NULL::BIGINT                                                             AS flush_lsn,
+               pg_last_wal_receive_lsn() - '0/0'                                        AS receive_lsn,
+               pg_last_wal_replay_lsn() - '0/0'                                         AS replay_lsn,
+               extract(EPOCH FROM now() - pg_conf_load_time())                          AS conf_reload_time,
+               extract(EPOCH FROM pg_last_xact_replay_timestamp())                      AS last_replay_time,
+               CASE
+                   WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
+                   ELSE EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()) END AS lag,
+               pg_is_in_recovery()                                                      AS is_in_recovery,
+               pg_is_wal_replay_paused()                                                AS is_wal_replay_paused;
+    tags:
+        - cluster
+        - replica
+    ttl: 1
+    timeout: 0.1
+    min_version: 150000
+    max_version: 0
+    fatal: true
+    skip: false
+    metrics:
+        - timestamp:
+            name: timestamp
+            usage: GAUGE
+            description: database current timestamp
+        - uptime:
+            name: uptime
+            usage: GAUGE
+            description: seconds since postmaster start
+        - boot_time:
+            name: boot_time
+            usage: GAUGE
+            description: unix timestamp when postmaster boot
+        - lsn:
+            name: lsn
+            usage: COUNTER
+            description: log sequence number, current write location
+        - insert_lsn:
+            name: insert_lsn
+            usage: COUNTER
+            description: primary only, location of current wal inserting
+        - write_lsn:
+            name: write_lsn
+            usage: COUNTER
+            description: primary only, location of current wal writing
+        - flush_lsn:
+            name: flush_lsn
+            usage: COUNTER
+            description: primary only, location of current wal syncing
+        - receive_lsn:
+            name: receive_lsn
+            usage: COUNTER
+            description: replica only, location of wal synced to disk
+        - replay_lsn:
+            name: replay_lsn
+            usage: COUNTER
+            description: replica only, location of wal applied
+        - conf_reload_time:
+            name: conf_reload_time
+            usage: GAUGE
+            description: seconds since last configuration reload
+        - last_replay_time:
+            name: last_replay_time
+            usage: GAUGE
+            description: time when last transaction been replayed
+        - lag:
+            name: lag
+            usage: GAUGE
+            description: replica only, replication lag in seconds
+        - is_in_recovery:
+            name: is_in_recovery
+            usage: GAUGE
+            description: 1 if in recovery mode
+        - is_wal_replay_paused:
+            name: is_wal_replay_paused
+            usage: GAUGE
+            description: 1 if wal play paused
 
 ##
 # SYNNOPSIS

--- a/support-pg15.patch
+++ b/support-pg15.patch
@@ -1,0 +1,632 @@
+diff --git a/config/collector/110-pg.yml b/config/collector/110-pg.yml
+index eb8c9c8..0236fcd 100644
+--- a/config/collector/110-pg.yml
++++ b/config/collector/110-pg.yml
+@@ -11,7 +11,7 @@
+ #       Priority   0
+ #       Timeout    100ms
+ #       Fatal      true
+-#       Version    100000 ~ higher
++#       Version    100000 ~ 150000
+ #       Source     110-pg.yml
+ #
+ # METRICS
+@@ -74,7 +74,7 @@ pg_primary_only:
+     ttl: 1
+     timeout: 0.1
+     min_version: 100000
+-    max_version: 0
++    max_version: 150000
+     fatal: true
+     skip: false
+     metrics:
+@@ -143,6 +143,137 @@ pg_primary_only:
+             usage: GAUGE
+             description: seconds since current backup start
+ 
++##
++# SYNNOPSIS
++#       pg.pg_primary_only_15_*
++#
++# DESCRIPTION
++#       PostgreSQL basic information (on primary)
++#
++# OPTIONS
++#       Tags       [cluster, primary]
++#       TTL        1
++#       Priority   0
++#       Timeout    100ms
++#       Fatal      true
++#       Version    150000 ~ higher
++#       Source     110-pg.yml
++#
++# METRICS
++#       timestamp (GAUGE)
++#           current database timestamp in unix epoch
++#       uptime (GAUGE)
++#           seconds since postmaster start
++#       boot_time (GAUGE)
++#           postmaster boot timestamp in unix epoch
++#       lsn (COUNTER)
++#           log sequence number, current write location
++#       insert_lsn (COUNTER)
++#           primary only, location of current wal inserting
++#       write_lsn (COUNTER)
++#           primary only, location of current wal writing
++#       flush_lsn (COUNTER)
++#           primary only, location of current wal syncing
++#       receive_lsn (COUNTER)
++#           replica only, location of wal synced to disk
++#       replay_lsn (COUNTER)
++#           replica only, location of wal applied
++#       conf_reload_time (GAUGE)
++#           seconds since last configuration reload
++#       last_replay_time (GAUGE)
++#           time when last transaction been replayed
++#       lag (GAUGE)
++#           replica only, replication lag in seconds
++#       is_in_recovery (GAUGE)
++#           1 if in recovery mode
++#       is_wal_replay_paused (GAUGE)
++#           1 if wal play is paused
++#
++pg_primary_only_15:
++    name: pg
++    desc: PostgreSQL basic information (on primary)
++    query: |
++        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                  AS timestamp,
++               extract(EPOCH FROM now() - pg_postmaster_start_time()) AS uptime,
++               extract(EPOCH FROM pg_postmaster_start_time())         AS boot_time,
++               pg_current_wal_lsn() - '0/0'                           AS lsn,
++               pg_current_wal_insert_lsn() - '0/0'                    AS insert_lsn,
++               pg_current_wal_lsn() - '0/0'                           AS write_lsn,
++               pg_current_wal_flush_lsn() - '0/0'                     AS flush_lsn,
++               NULL::BIGINT                                           AS receive_lsn,
++               NULL::BIGINT                                           AS replay_lsn,
++               extract(EPOCH FROM now() - pg_conf_load_time())        AS conf_reload_time,
++               NULL::FLOAT                                            AS last_replay_time,
++               0::FLOAT                                               AS lag,
++               pg_is_in_recovery()                                    AS is_in_recovery,
++               FALSE                                                  AS is_wal_replay_paused;
++    tags:
++        - cluster
++        - primary
++    ttl: 1
++    timeout: 0.1
++    min_version: 150000
++    max_version: 0
++    fatal: true
++    skip: false
++    metrics:
++        - timestamp:
++            name: timestamp
++            usage: GAUGE
++            description: current database timestamp in unix epoch
++        - uptime:
++            name: uptime
++            usage: GAUGE
++            description: seconds since postmaster start
++        - boot_time:
++            name: boot_time
++            usage: GAUGE
++            description: postmaster boot timestamp in unix epoch
++        - lsn:
++            name: lsn
++            usage: COUNTER
++            description: log sequence number, current write location
++        - insert_lsn:
++            name: insert_lsn
++            usage: COUNTER
++            description: primary only, location of current wal inserting
++        - write_lsn:
++            name: write_lsn
++            usage: COUNTER
++            description: primary only, location of current wal writing
++        - flush_lsn:
++            name: flush_lsn
++            usage: COUNTER
++            description: primary only, location of current wal syncing
++        - receive_lsn:
++            name: receive_lsn
++            usage: COUNTER
++            description: replica only, location of wal synced to disk
++        - replay_lsn:
++            name: replay_lsn
++            usage: COUNTER
++            description: replica only, location of wal applied
++        - conf_reload_time:
++            name: conf_reload_time
++            usage: GAUGE
++            description: seconds since last configuration reload
++        - last_replay_time:
++            name: last_replay_time
++            usage: GAUGE
++            description: time when last transaction been replayed
++        - lag:
++            name: lag
++            usage: GAUGE
++            description: replica only, replication lag in seconds
++        - is_in_recovery:
++            name: is_in_recovery
++            usage: GAUGE
++            description: 1 if in recovery mode
++        - is_wal_replay_paused:
++            name: is_wal_replay_paused
++            usage: GAUGE
++            description: 1 if wal play is paused
++
+ ##
+ # SYNNOPSIS
+ #       pg.pg_replica_only_*
+@@ -156,7 +287,7 @@ pg_primary_only:
+ #       Priority   0
+ #       Timeout    100ms
+ #       Fatal      true
+-#       Version    100000 ~ higher
++#       Version    100000 ~ 150000
+ #       Source     110-pg.yml
+ #
+ # METRICS
+@@ -221,7 +352,7 @@ pg_replica_only:
+     ttl: 1
+     timeout: 0.1
+     min_version: 100000
+-    max_version: 0
++    max_version: 150000
+     fatal: true
+     skip: false
+     metrics:
+@@ -290,4 +421,136 @@ pg_replica_only:
+             usage: GAUGE
+             description: seconds since current backup start
+ 
++##
++# SYNNOPSIS
++#       pg.pg_replica_only_15_*
++#
++# DESCRIPTION
++#       PostgreSQL basic information (on replica)
++#
++# OPTIONS
++#       Tags       [cluster, replica]
++#       TTL        1
++#       Priority   0
++#       Timeout    100ms
++#       Fatal      true
++#       Version    150000 ~ higher
++#       Source     110-pg.yml
++#
++# METRICS
++#       timestamp (GAUGE)
++#           database current timestamp
++#       uptime (GAUGE)
++#           seconds since postmaster start
++#       boot_time (GAUGE)
++#           unix timestamp when postmaster boot
++#       lsn (COUNTER)
++#           log sequence number, current write location
++#       insert_lsn (COUNTER)
++#           primary only, location of current wal inserting
++#       write_lsn (COUNTER)
++#           primary only, location of current wal writing
++#       flush_lsn (COUNTER)
++#           primary only, location of current wal syncing
++#       receive_lsn (COUNTER)
++#           replica only, location of wal synced to disk
++#       replay_lsn (COUNTER)
++#           replica only, location of wal applied
++#       conf_reload_time (GAUGE)
++#           seconds since last configuration reload
++#       last_replay_time (GAUGE)
++#           time when last transaction been replayed
++#       lag (GAUGE)
++#           replica only, replication lag in seconds
++#       is_in_recovery (GAUGE)
++#           1 if in recovery mode
++#       is_wal_replay_paused (GAUGE)
++#           1 if wal play paused
++#
++pg_replica_only_15:
++    name: pg
++    desc: PostgreSQL basic information (on replica)
++    query: |
++        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                                    AS timestamp,
++               extract(EPOCH FROM now() - pg_postmaster_start_time())                   AS uptime,
++               extract(EPOCH FROM pg_postmaster_start_time())                           AS boot_time,
++               pg_last_wal_replay_lsn() - '0/0'                                         AS lsn,
++               NULL::BIGINT                                                             AS insert_lsn,
++               NULL::BIGINT                                                             AS write_lsn,
++               NULL::BIGINT                                                             AS flush_lsn,
++               pg_last_wal_receive_lsn() - '0/0'                                        AS receive_lsn,
++               pg_last_wal_replay_lsn() - '0/0'                                         AS replay_lsn,
++               extract(EPOCH FROM now() - pg_conf_load_time())                          AS conf_reload_time,
++               extract(EPOCH FROM pg_last_xact_replay_timestamp())                      AS last_replay_time,
++               CASE
++                   WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
++                   ELSE EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()) END AS lag,
++               pg_is_in_recovery()                                                      AS is_in_recovery,
++               pg_is_wal_replay_paused()                                                AS is_wal_replay_paused;
++    tags:
++        - cluster
++        - replica
++    ttl: 1
++    timeout: 0.1
++    min_version: 150000
++    max_version: 0
++    fatal: true
++    skip: false
++    metrics:
++        - timestamp:
++            name: timestamp
++            usage: GAUGE
++            description: database current timestamp
++        - uptime:
++            name: uptime
++            usage: GAUGE
++            description: seconds since postmaster start
++        - boot_time:
++            name: boot_time
++            usage: GAUGE
++            description: unix timestamp when postmaster boot
++        - lsn:
++            name: lsn
++            usage: COUNTER
++            description: log sequence number, current write location
++        - insert_lsn:
++            name: insert_lsn
++            usage: COUNTER
++            description: primary only, location of current wal inserting
++        - write_lsn:
++            name: write_lsn
++            usage: COUNTER
++            description: primary only, location of current wal writing
++        - flush_lsn:
++            name: flush_lsn
++            usage: COUNTER
++            description: primary only, location of current wal syncing
++        - receive_lsn:
++            name: receive_lsn
++            usage: COUNTER
++            description: replica only, location of wal synced to disk
++        - replay_lsn:
++            name: replay_lsn
++            usage: COUNTER
++            description: replica only, location of wal applied
++        - conf_reload_time:
++            name: conf_reload_time
++            usage: GAUGE
++            description: seconds since last configuration reload
++        - last_replay_time:
++            name: last_replay_time
++            usage: GAUGE
++            description: time when last transaction been replayed
++        - lag:
++            name: lag
++            usage: GAUGE
++            description: replica only, replication lag in seconds
++        - is_in_recovery:
++            name: is_in_recovery
++            usage: GAUGE
++            description: 1 if in recovery mode
++        - is_wal_replay_paused:
++            name: is_wal_replay_paused
++            usage: GAUGE
++            description: 1 if wal play paused
+ 
+diff --git a/pg_exporter.yml b/pg_exporter.yml
+index 509dee2..855711d 100644
+--- a/pg_exporter.yml
++++ b/pg_exporter.yml
+@@ -211,7 +211,7 @@
+ #       Priority   0
+ #       Timeout    100ms
+ #       Fatal      true
+-#       Version    100000 ~ higher
++#       Version    100000 ~ 150000
+ #       Source     110-pg.yml
+ #
+ # METRICS
+@@ -274,7 +274,7 @@ pg_primary_only:
+     ttl: 1
+     timeout: 0.1
+     min_version: 100000
+-    max_version: 0
++    max_version: 150000
+     fatal: true
+     skip: false
+     metrics:
+@@ -343,6 +343,137 @@ pg_primary_only:
+             usage: GAUGE
+             description: seconds since current backup start
+ 
++##
++# SYNNOPSIS
++#       pg.pg_primary_only_15_*
++#
++# DESCRIPTION
++#       PostgreSQL basic information (on primary)
++#
++# OPTIONS
++#       Tags       [cluster, primary]
++#       TTL        1
++#       Priority   0
++#       Timeout    100ms
++#       Fatal      true
++#       Version    150000 ~ higher
++#       Source     110-pg.yml
++#
++# METRICS
++#       timestamp (GAUGE)
++#           current database timestamp in unix epoch
++#       uptime (GAUGE)
++#           seconds since postmaster start
++#       boot_time (GAUGE)
++#           postmaster boot timestamp in unix epoch
++#       lsn (COUNTER)
++#           log sequence number, current write location
++#       insert_lsn (COUNTER)
++#           primary only, location of current wal inserting
++#       write_lsn (COUNTER)
++#           primary only, location of current wal writing
++#       flush_lsn (COUNTER)
++#           primary only, location of current wal syncing
++#       receive_lsn (COUNTER)
++#           replica only, location of wal synced to disk
++#       replay_lsn (COUNTER)
++#           replica only, location of wal applied
++#       conf_reload_time (GAUGE)
++#           seconds since last configuration reload
++#       last_replay_time (GAUGE)
++#           time when last transaction been replayed
++#       lag (GAUGE)
++#           replica only, replication lag in seconds
++#       is_in_recovery (GAUGE)
++#           1 if in recovery mode
++#       is_wal_replay_paused (GAUGE)
++#           1 if wal play is paused
++#
++pg_primary_only_15:
++    name: pg
++    desc: PostgreSQL basic information (on primary)
++    query: |
++        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                  AS timestamp,
++               extract(EPOCH FROM now() - pg_postmaster_start_time()) AS uptime,
++               extract(EPOCH FROM pg_postmaster_start_time())         AS boot_time,
++               pg_current_wal_lsn() - '0/0'                           AS lsn,
++               pg_current_wal_insert_lsn() - '0/0'                    AS insert_lsn,
++               pg_current_wal_lsn() - '0/0'                           AS write_lsn,
++               pg_current_wal_flush_lsn() - '0/0'                     AS flush_lsn,
++               NULL::BIGINT                                           AS receive_lsn,
++               NULL::BIGINT                                           AS replay_lsn,
++               extract(EPOCH FROM now() - pg_conf_load_time())        AS conf_reload_time,
++               NULL::FLOAT                                            AS last_replay_time,
++               0::FLOAT                                               AS lag,
++               pg_is_in_recovery()                                    AS is_in_recovery,
++               FALSE                                                  AS is_wal_replay_paused;
++    tags:
++        - cluster
++        - primary
++    ttl: 1
++    timeout: 0.1
++    min_version: 150000
++    max_version: 0
++    fatal: true
++    skip: false
++    metrics:
++        - timestamp:
++            name: timestamp
++            usage: GAUGE
++            description: current database timestamp in unix epoch
++        - uptime:
++            name: uptime
++            usage: GAUGE
++            description: seconds since postmaster start
++        - boot_time:
++            name: boot_time
++            usage: GAUGE
++            description: postmaster boot timestamp in unix epoch
++        - lsn:
++            name: lsn
++            usage: COUNTER
++            description: log sequence number, current write location
++        - insert_lsn:
++            name: insert_lsn
++            usage: COUNTER
++            description: primary only, location of current wal inserting
++        - write_lsn:
++            name: write_lsn
++            usage: COUNTER
++            description: primary only, location of current wal writing
++        - flush_lsn:
++            name: flush_lsn
++            usage: COUNTER
++            description: primary only, location of current wal syncing
++        - receive_lsn:
++            name: receive_lsn
++            usage: COUNTER
++            description: replica only, location of wal synced to disk
++        - replay_lsn:
++            name: replay_lsn
++            usage: COUNTER
++            description: replica only, location of wal applied
++        - conf_reload_time:
++            name: conf_reload_time
++            usage: GAUGE
++            description: seconds since last configuration reload
++        - last_replay_time:
++            name: last_replay_time
++            usage: GAUGE
++            description: time when last transaction been replayed
++        - lag:
++            name: lag
++            usage: GAUGE
++            description: replica only, replication lag in seconds
++        - is_in_recovery:
++            name: is_in_recovery
++            usage: GAUGE
++            description: 1 if in recovery mode
++        - is_wal_replay_paused:
++            name: is_wal_replay_paused
++            usage: GAUGE
++            description: 1 if wal play is paused
++
+ ##
+ # SYNNOPSIS
+ #       pg.pg_replica_only_*
+@@ -356,7 +487,7 @@ pg_primary_only:
+ #       Priority   0
+ #       Timeout    100ms
+ #       Fatal      true
+-#       Version    100000 ~ higher
++#       Version    100000 ~ 150000
+ #       Source     110-pg.yml
+ #
+ # METRICS
+@@ -421,7 +552,7 @@ pg_replica_only:
+     ttl: 1
+     timeout: 0.1
+     min_version: 100000
+-    max_version: 0
++    max_version: 150000
+     fatal: true
+     skip: false
+     metrics:
+@@ -490,6 +621,138 @@ pg_replica_only:
+             usage: GAUGE
+             description: seconds since current backup start
+ 
++##
++# SYNNOPSIS
++#       pg.pg_replica_only_15_*
++#
++# DESCRIPTION
++#       PostgreSQL basic information (on replica)
++#
++# OPTIONS
++#       Tags       [cluster, replica]
++#       TTL        1
++#       Priority   0
++#       Timeout    100ms
++#       Fatal      true
++#       Version    150000 ~ higher
++#       Source     110-pg.yml
++#
++# METRICS
++#       timestamp (GAUGE)
++#           database current timestamp
++#       uptime (GAUGE)
++#           seconds since postmaster start
++#       boot_time (GAUGE)
++#           unix timestamp when postmaster boot
++#       lsn (COUNTER)
++#           log sequence number, current write location
++#       insert_lsn (COUNTER)
++#           primary only, location of current wal inserting
++#       write_lsn (COUNTER)
++#           primary only, location of current wal writing
++#       flush_lsn (COUNTER)
++#           primary only, location of current wal syncing
++#       receive_lsn (COUNTER)
++#           replica only, location of wal synced to disk
++#       replay_lsn (COUNTER)
++#           replica only, location of wal applied
++#       conf_reload_time (GAUGE)
++#           seconds since last configuration reload
++#       last_replay_time (GAUGE)
++#           time when last transaction been replayed
++#       lag (GAUGE)
++#           replica only, replication lag in seconds
++#       is_in_recovery (GAUGE)
++#           1 if in recovery mode
++#       is_wal_replay_paused (GAUGE)
++#           1 if wal play paused
++#
++pg_replica_only_15:
++    name: pg
++    desc: PostgreSQL basic information (on replica)
++    query: |
++        SELECT extract(EPOCH FROM CURRENT_TIMESTAMP)                                    AS timestamp,
++               extract(EPOCH FROM now() - pg_postmaster_start_time())                   AS uptime,
++               extract(EPOCH FROM pg_postmaster_start_time())                           AS boot_time,
++               pg_last_wal_replay_lsn() - '0/0'                                         AS lsn,
++               NULL::BIGINT                                                             AS insert_lsn,
++               NULL::BIGINT                                                             AS write_lsn,
++               NULL::BIGINT                                                             AS flush_lsn,
++               pg_last_wal_receive_lsn() - '0/0'                                        AS receive_lsn,
++               pg_last_wal_replay_lsn() - '0/0'                                         AS replay_lsn,
++               extract(EPOCH FROM now() - pg_conf_load_time())                          AS conf_reload_time,
++               extract(EPOCH FROM pg_last_xact_replay_timestamp())                      AS last_replay_time,
++               CASE
++                   WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
++                   ELSE EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()) END AS lag,
++               pg_is_in_recovery()                                                      AS is_in_recovery,
++               pg_is_wal_replay_paused()                                                AS is_wal_replay_paused;
++    tags:
++        - cluster
++        - replica
++    ttl: 1
++    timeout: 0.1
++    min_version: 150000
++    max_version: 0
++    fatal: true
++    skip: false
++    metrics:
++        - timestamp:
++            name: timestamp
++            usage: GAUGE
++            description: database current timestamp
++        - uptime:
++            name: uptime
++            usage: GAUGE
++            description: seconds since postmaster start
++        - boot_time:
++            name: boot_time
++            usage: GAUGE
++            description: unix timestamp when postmaster boot
++        - lsn:
++            name: lsn
++            usage: COUNTER
++            description: log sequence number, current write location
++        - insert_lsn:
++            name: insert_lsn
++            usage: COUNTER
++            description: primary only, location of current wal inserting
++        - write_lsn:
++            name: write_lsn
++            usage: COUNTER
++            description: primary only, location of current wal writing
++        - flush_lsn:
++            name: flush_lsn
++            usage: COUNTER
++            description: primary only, location of current wal syncing
++        - receive_lsn:
++            name: receive_lsn
++            usage: COUNTER
++            description: replica only, location of wal synced to disk
++        - replay_lsn:
++            name: replay_lsn
++            usage: COUNTER
++            description: replica only, location of wal applied
++        - conf_reload_time:
++            name: conf_reload_time
++            usage: GAUGE
++            description: seconds since last configuration reload
++        - last_replay_time:
++            name: last_replay_time
++            usage: GAUGE
++            description: time when last transaction been replayed
++        - lag:
++            name: lag
++            usage: GAUGE
++            description: replica only, replication lag in seconds
++        - is_in_recovery:
++            name: is_in_recovery
++            usage: GAUGE
++            description: 1 if in recovery mode
++        - is_wal_replay_paused:
++            name: is_wal_replay_paused
++            usage: GAUGE
++            description: 1 if wal play paused
+ 
+ ##
+ # SYNNOPSIS


### PR DESCRIPTION
Ths pg_is_in_backup() and pg_backup_start_time() have been removed in PostgreSQL 15. See: https://www.postgresql.org/docs/release/15.0/

Remove {pg_primary_only_,pg_replica_only_}{is_in_backup,backup_time} metrics for PostgreSQL 15 and higher.