### PR TITLE
pg_exporter: fix /stat endpoint formatting

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -570,7 +570,7 @@ func (e *Exporter) ExplainFunc(w http.ResponseWriter, r *http.Request) {
 
 // StatFunc expose html statistics
 func (e *Exporter) StatFunc(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
 	_, _ = w.Write([]byte(e.Stat()))
 }
 


### PR DESCRIPTION
Send text/plain for requests to the /stat endpoint so browser visits will render it correctly.

It should really respect the client's Accept header and render to json or similar when requested, but that's a bigger job.