### PR TITLE
Exclude template DBs from discovery and schema-qualify discovery query

### DIFF
--- a/exporter/server.go
+++ b/exporter/server.go
@@ -202,10 +202,10 @@ func PostgresPrecheck(s *Server) (err error) {
 	var recovery bool
 	var datname, username string
 	var databases, namespaces, extensions []string
-	precheckSQL := `SELECT current_catalog, current_user, pg_is_in_recovery(),       
-	(SELECT array_agg(datname) AS databases FROM pg_database),
-	(SELECT array_agg(nspname) AS namespaces FROM pg_namespace),
-	(SELECT array_agg(extname) AS extensions FROM pg_extension);`
+	precheckSQL := `SELECT current_catalog, current_user, pg_catalog.pg_is_in_recovery(),
+	(SELECT pg_catalog.array_agg(d.datname) AS databases FROM pg_catalog.pg_database d),
+	(SELECT pg_catalog.array_agg(n.nspname) AS namespaces FROM pg_catalog.pg_namespace n),
+	(SELECT pg_catalog.array_agg(e.extname) AS extensions FROM pg_catalog.pg_extension e);`
 	ctx, cancel2 := context.WithTimeout(context.Background(), s.GetConnectTimeout())
 	defer cancel2()
 	//if err = s.DB.QueryRowContext(ctx, precheckSQL).Scan(&datname, &username, &recovery, &databases, &namespaces, &extensions); err != nil {

--- a/exporter/server.go
+++ b/exporter/server.go
@@ -203,7 +203,7 @@ func PostgresPrecheck(s *Server) (err error) {
 	var datname, username string
 	var databases, namespaces, extensions []string
 	precheckSQL := `SELECT current_catalog, current_user, pg_catalog.pg_is_in_recovery(),
-	(SELECT pg_catalog.array_agg(d.datname) AS databases FROM pg_catalog.pg_database d),
+	(SELECT pg_catalog.array_agg(d.datname) AS databases FROM pg_catalog.pg_database d WHERE d.datallowconn AND NOT d.datistemplate),
 	(SELECT pg_catalog.array_agg(n.nspname) AS namespaces FROM pg_catalog.pg_namespace n),
 	(SELECT pg_catalog.array_agg(e.extname) AS extensions FROM pg_catalog.pg_extension e);`
 	ctx, cancel2 := context.WithTimeout(context.Background(), s.GetConnectTimeout())


### PR DESCRIPTION
When doing database auto-discovery, exclude all databases marked as templates and any databases that do not allow connections.
    
It's conceivable, but not very likely, that someone could want to scrape metrics from a template DB, but pg_exporter currently defaults to excluding template1 anyway. postgres_exporter also has the same behaviour of excluding template DBs from discovery. So I did not add a CLI option to override this behaviour.

Additionally, schema-qualify references to `pg_database` and the `pg_is_in_recovery` function call in the database discovery query to guarantee protection against any possible `search_path` based attacks. I can't immediately see how it'd be possible in this case, so it's not a vulnerability, but it's best practice to always schema-qualify everything in any query that could possibly be run as a privileged role.