### PR TITLE
Fix some typos and some metric description mistakes

### DIFF
--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -69,7 +69,7 @@ func (q *Collector) Collect(ch chan<- prometheus.Metric) {
 	q.sendMetrics(ch) // the cache is already reset to zero even execute failed
 }
 
-// ResultSize report last scrapped metric count
+// ResultSize report last scraped metric count
 func (q *Collector) ResultSize() int {
 	return len(q.result)
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -18,7 +18,7 @@ type Exporter struct {
 	// config params provided from ExporterOpt
 	dsn             string            // primary dsn
 	configPath      string            // config file path /directory
-	disableCache    bool              // always execute query when been scrapped
+	disableCache    bool              // always execute query when been scraped
 	disableIntro    bool              // disable query level introspection metrics
 	autoDiscovery   bool              // discovery other database on primary server
 	pgbouncerMode   bool              // is primary server a pgbouncer ?
@@ -54,8 +54,8 @@ type Exporter struct {
 
 	serverScrapeDuration     *prometheus.GaugeVec // {datname} database level: how much time spend on server scrape?
 	serverScrapeTotalSeconds *prometheus.GaugeVec // {datname} database level: how much time spend on server scrape?
-	serverScrapeTotalCount   *prometheus.GaugeVec // {datname} database level how many metrics scrapped from server
-	serverScrapeErrorCount   *prometheus.GaugeVec // {datname} database level: how many error occurs when scrapping server
+	serverScrapeTotalCount   *prometheus.GaugeVec // {datname} database level how many metrics scraped from server
+	serverScrapeErrorCount   *prometheus.GaugeVec // {datname} database level: how many error occurs when scraping server
 
 	queryCacheTTL          *prometheus.GaugeVec // {datname,query} query cache ttl
 	queryScrapeTotalCount  *prometheus.GaugeVec // {datname,query} query level: how many errors the query triggers?
@@ -257,7 +257,7 @@ func (e *Exporter) setupInternalMetrics() {
 	})
 	e.scrapeDuration = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter", Name: "scrape_duration", Help: "seconds exporter spending on scrapping",
+		Subsystem: "exporter", Name: "scrape_duration", Help: "seconds exporter spending on scraping",
 	})
 	e.lastScrapeTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
@@ -297,15 +297,15 @@ func (e *Exporter) setupInternalMetrics() {
 	}, []string{"datname", "query"})
 	e.queryScrapeDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter_query", Name: "scrape_duration", Help: "seconds query spending on scrapping",
+		Subsystem: "exporter_query", Name: "scrape_duration", Help: "seconds query spending on scraping",
 	}, []string{"datname", "query"})
 	e.queryScrapeMetricCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter_query", Name: "scrape_metric_count", Help: "numbers of metrics been scrapped from this query",
+		Subsystem: "exporter_query", Name: "scrape_metric_count", Help: "numbers of metrics been scraped from this query",
 	}, []string{"datname", "query"})
 	e.queryScrapeHitCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter_query", Name: "scrape_hit_count", Help: "numbers been scrapped from this query",
+		Subsystem: "exporter_query", Name: "scrape_hit_count", Help: "numbers been scraped from this query",
 	}, []string{"datname", "query"})
 
 	e.exporterUp.Set(1) // always be true
@@ -353,7 +353,7 @@ func NewExporter(dsn string, opts ...ExporterOpt) (e *Exporter, err error) {
 	}
 	logDebugf("exporter init with %d queries", len(e.queries))
 
-	// note here the server is still not connected. it will trigger connecting when being scrapped
+	// note here the server is still not connected. it will trigger connecting when being scraped
 	e.server = NewServer(
 		dsn,
 		WithQueries(e.queries),

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -261,17 +261,17 @@ func (e *Exporter) setupInternalMetrics() {
 	})
 	e.lastScrapeTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter", Name: "last_scrape_time", Help: "seconds exporter spending on scrapping",
+		Subsystem: "exporter", Name: "last_scrape_time", Help: "last scrape timestamp",
 	})
 
 	// exporter level metrics
 	e.serverScrapeDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter_server", Name: "scrape_duration", Help: "seconds exporter server spending on scrapping",
+		Subsystem: "exporter_server", Name: "scrape_duration", Help: "seconds exporter server spending on scraping last scrape",
 	}, []string{"datname"})
 	e.serverScrapeTotalSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,
-		Subsystem: "exporter_server", Name: "scrape_total_seconds", Help: "seconds exporter server spending on scrapping",
+		Subsystem: "exporter_server", Name: "scrape_total_seconds", Help: "cumulative total seconds exporter server spending on scraping",
 	}, []string{"datname"})
 	e.serverScrapeTotalCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace, ConstLabels: e.constLabels,

--- a/exporter/server.go
+++ b/exporter/server.go
@@ -77,7 +77,7 @@ type Server struct {
 	queryScrapeTotalCount  map[string]float64 // internal query metrics: total executed
 	queryScrapeHitCount    map[string]float64 // internal query metrics: times serving from hit cache
 	queryScrapeErrorCount  map[string]float64 // internal query metrics: times failed
-	queryScrapeMetricCount map[string]float64 // internal query metrics: number of metrics scrapped
+	queryScrapeMetricCount map[string]float64 // internal query metrics: number of metrics scraped
 	queryScrapeDuration    map[string]float64 // internal query metrics: time spend on executing
 }
 
@@ -518,10 +518,10 @@ final:
 	if s.err != nil {
 		s.UP = false
 		s.errorCount++
-		logErrorf("fail scrapping server [%s]: %s", s.Name(), s.err.Error())
+		logErrorf("fail scraping server [%s]: %s", s.Name(), s.err.Error())
 	} else {
 		s.UP = true
-		logDebugf("server [%s] scrapped in %v",
+		logDebugf("server [%s] scraped in %v",
 			s.Name(), s.scrapeDone.Sub(s.scrapeBegin).Seconds())
 	}
 }


### PR DESCRIPTION
Fix metric descriptions on `last_scrape_time`, `scrape_duration`, `scrape_total_seconds`.

Change "scrapped" to "scraped"